### PR TITLE
NBT integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 test/
+test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,8 +56,8 @@ dependencies = [
 
 [[package]]
 name = "named-binary-tag"
-version = "0.6.1"
-source = "git+https://github.com/mrghosti3/named-binary-tag.git?branch=feature/archive#1b75d9ad6efdf8e6215be589d77b00a0352c4b47"
+version = "0.6.1-dev"
+source = "git+https://github.com/mrghosti3/named-binary-tag.git?branch=dev#5f6e6d5f11274e3713901e617ba7937af5b064e5"
 dependencies = [
  "byteorder",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -47,18 +47,17 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "named-binary-tag"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523298fac63bd954f9a2e03b962b8a4a0e95110ad1b2fa3e0d7048660ffecec3"
+version = "0.6.1"
+source = "git+https://github.com/mrghosti3/named-binary-tag.git?branch=feature/archive#1b75d9ad6efdf8e6215be589d77b00a0352c4b47"
 dependencies = [
  "byteorder",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,10 +46,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -56,12 +87,13 @@ dependencies = [
 
 [[package]]
 name = "named-binary-tag"
-version = "0.6.1-dev"
-source = "git+https://github.com/mrghosti3/named-binary-tag.git?branch=dev#5f6e6d5f11274e3713901e617ba7937af5b064e5"
+version = "0.7.0-dev"
+source = "git+https://github.com/mrghosti3/named-binary-tag.git?branch=dev#0117f79be5ab5053d5dd0a9034e7d9bf408d5e90"
 dependencies = [
  "byteorder",
  "flate2",
  "linked-hash-map",
+ "serde",
 ]
 
 [[package]]
@@ -69,4 +101,85 @@ name = "nbt-editor"
 version = "0.1.0"
 dependencies = [
  "named-binary-tag",
+ "serde_yaml",
 ]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "serde"
+version = "1.0.163"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.163"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ edition = "2021"
 [dependencies.nbt]
 package = "named-binary-tag"
 features = ["archive"]
-version = "0.6.1"
+version = "0.6.1-dev"
 git = "https://github.com/mrghosti3/named-binary-tag.git"
-branch = "feature/archive"
+branch = "dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-named-binary-tag = "0.6.0"
+
+[dependencies.nbt]
+package = "named-binary-tag"
+features = ["archive"]
+version = "0.6.1"
+git = "https://github.com/mrghosti3/named-binary-tag.git"
+branch = "feature/archive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde_yaml = "0.9.21"
 
 [dependencies.nbt]
 package = "named-binary-tag"
-features = ["archive"]
-version = "0.6.1-dev"
+features = ["archive", "serde"]
+# version = "0.7.0-dev"
 git = "https://github.com/mrghosti3/named-binary-tag.git"
 branch = "dev"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,56 +1,18 @@
-use std::{io, fs};
-use nbt::{Tag, CompoundTag};
+use nbt::archive::enflate;
+use std::{env, fs, io};
 
 fn main() {
-    let mut buf = open_file("test/level.dat");
-    let root_tag = nbt::decode::read_gzip_compound_tag(&mut buf).expect("Unable to decode!");
+    let args = env::args()
+        .skip(1)
+        .next()
+        .expect("Missing filename to NBT data.");
+    let mut buf = open_file(&args);
+    let root_tag = enflate::read_gzip_compound_tag(&mut buf).expect("Unable to decode!");
 
-    print_tags(0, &root_tag);
+    println!("{}", serde_yaml::to_string(&root_tag).unwrap());
 }
 
 fn open_file(fname: &str) -> io::BufReader<fs::File> {
     let file = fs::File::open(fname).expect("Unable to open file");
     io::BufReader::new(file)
-}
-
-/// Prints NBT data to stdout simirral to JSON format.
-/// FIX: Move away from recursion.
-fn print_tags(i: usize, root: &CompoundTag) {
-    print_ctag(i, root);
-
-    let indent = i + 2;
-    for el in root.iter() {
-        if let Tag::Compound(ctag) = el.1 {
-            print_tags(indent, ctag);
-        } else {
-            print_tag(indent, el.0, el.1);
-        }
-    }
-
-    if !root.is_empty() {
-        println!("{}}}", " ".repeat(i));
-    }
-}
-
-fn print_ctag(i: usize, ctag: &CompoundTag) {
-    let space = " ".repeat(i);
-    let name = match &ctag.name {
-        Some(name) => name,
-        None => ""
-    };
-    let curly = match ctag.is_empty() {
-        true => "{}",
-        false => "{"
-    };
-    println!("{space}\"{name}\" : {curly}");
-}
-
-fn print_tag(i: usize, name: &String, tag: &Tag) {
-    let space = " ".repeat(i);
-    let value = if let Tag::String(val) = tag {
-        format!("\"{}\"", val)
-    } else {
-        tag.to_string()
-    };
-    println!("{space}\"{name}\" : {value}");
 }


### PR DESCRIPTION
Initial integration with NBT lib ([name-binary-tag](https://github.com/eihwaz/named-binary-tag) fork). The fork used here implements `[serde](https://github.com/serde-rs/serde)` making it easier to integrate converting NBT format to human readable formats (this case YML). Since the project is still in experimental stage, the experimental version of the fork will suffice for now.

Closes #2
Closes #3 